### PR TITLE
Resolve current issues with the tool

### DIFF
--- a/lib/ossa_functions
+++ b/lib/ossa_functions
@@ -128,7 +128,7 @@ elif [[ ${EOL_DAYS_REMAINING} -lt 365 ]];then EOL_DAYS_REMAINING=$(printf "\e[38
 elif [[ ${EOL_DAYS_REMAINING} -gt 365 ]];then EOL_DAYS_REMAINING=$(printf "\e[38;2;0;235;0m${EOL_DAYS_REMAINING} days\e[0m ($(date -d "$(date +${EOL_END})" '+%d/%b/%Y'))");fi
 [[ ${EL} = 0 ]] && EOL_DAYS_REMAINING=$(printf "\e[38;2;160;160;160;3mN/A\e[0m")
 echo "Ubuntu ${RELEASE^}|${CN1^} ${CN2^}|${FLAG^}|${EOS_DAYS_REMAINING}|${EOL_DAYS_REMAINING}"
-done))|column -nexts"|"|sed 's/^Release.*$/'$(printf "\e[1m&\e[0m")'/g'|/bin/grep -E "Release|${OSSA_CODENAME^}"|tee ${OSSA_WORKDIR}/release-info-ansi|sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'|tee 1>/dev/null ${OSSA_WORKDIR}/release-info
+done))|column -tnexs"|"|sed 's/^Release.*$/'$(printf "\e[1m&\e[0m")'/g'|/bin/grep -E "Release|${OSSA_CODENAME^}"|tee ${OSSA_WORKDIR}/release-info-ansi|sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'|tee 1>/dev/null ${OSSA_WORKDIR}/release-info
 };export -f show-release-info
 
 make-origin-table() {

--- a/ossa-generator/generator.sh
+++ b/ossa-generator/generator.sh
@@ -173,7 +173,7 @@ if [[ -f ${OSSA_WORKDIR}/apt-madison.out ]];then
 	printf '%s|%s|%s|%s|%s|%s|%s\n' ${COMPONENTS[2]} ${MULTIVERSE[0]##*:} ${MULTIVERSE[1]##*:} ${MULTIVERSE[2]##*:} ${MULTIVERSE[3]##*:} ${MULTIVERSE[4]##*:} ${MULTIVERSE[5]##*:}
 	printf '%s|%s|%s|%s|%s|%s|%s\n' ${COMPONENTS[3]} ${RESTRICTED[0]##*:} ${RESTRICTED[1]##*:} ${RESTRICTED[2]##*:} ${RESTRICTED[3]##*:} ${RESTRICTED[4]##*:} ${RESTRICTED[5]##*:}
 	printf '%s|%s|%s|%s|%s|%s|%s\n' Totals ${COMPONENT_TOTAL} ${RELEASE_TOTAL} ${UPDATES_TOTAL} ${SECURITY_TOTAL} ${BACKPORTS_TOTAL} ${PROPOSED_TOTAL}
-	)|column -nexts"|"|tee ${OSSA_WORKDIR}/package_table.txt| \
+	)|column -tnexs"|"|tee ${OSSA_WORKDIR}/package_table.txt| \
 	sed -re '1s/Ubuntu '${OSSA_CODENAME^}'/'$(printf "\e[1;48;2;233;84;32m\e[1;38;2;255;255;255m")'&'$(printf "\e[0m")'/' \
 		-re '1s/'${OSSA_CODENAME}'/'$(printf "\e[38;2;0;255;0m")'&'$(printf "\e[0m")'/' \
 		-re '1s/'${OSSA_HOST}'/'$(printf "\e[1;48;2;255;255;255m\e[1;38;2;233;84;32m")'&'$(printf "\e[0m")'/' \

--- a/ossa-generator/generator.sh
+++ b/ossa-generator/generator.sh
@@ -224,7 +224,7 @@ fi
 
 # Test for presence of  OVAL data for Ubuntu release that is being assessed 
 [[ ${VERBOSE} = true ]] && { printf "\e[2G - Checking the availability of OVAL Data for Ubuntu ${OSSA_CODENAME}\n"; }
-export OVAL_URI="https://people.canonical.com/~ubuntu-security/oval/oci.com.ubuntu.${OSSA_CODENAME}.cve.oval.xml.bz2"
+export OVAL_URI="https://security-metadata.canonical.com/oval/oci.com.ubuntu.${OSSA_CODENAME}.cve.oval.xml.bz2"
 [[ ${VERBOSE} = true ]] && { printf "\e[2G - OVAL URL: ${OVAL_URI}\n"; }
 export TEST_OVAL=$(curl -slSL --connect-timeout 10 --max-time 30 --retry 2 --retry-delay 2 -w %{http_code} -o /dev/null ${OVAL_URI} 2>&1)
 [[ ${OSSA_DEBUG} = true ]] && { echo "URL Test Results: ${TEST_OVAL}"; }


### PR DESCRIPTION
1. Incorrect OVAL_URI

The old OVAL_URI `https://people.canonical.com/~ubuntu-security/oval/` does not work.

The new up-to-date is
`https://security-metadata.canonical.com/oval/`

2. column command require correct order of argument now
`column: option --table required for all --table-*`

```
  - OVAL URL: https://people.canonical.com/~ubuntu-security/oval/oci.com.ubuntu.noble.cve.oval.xml.bz2
  - Displaying "release-info"
  - Displaying "package-table"






  - ERROR: Cannot perform CVE Scan
REASON: OVAL data file for Ubuntu Noble is not available. Skipping download.






OSSA Generator for earl completed in 00:00:07
```