### PR TITLE
fix for the newer xargs (since Jammy)

### DIFF
--- a/lib/ossa_functions
+++ b/lib/ossa_functions
@@ -99,7 +99,7 @@ svars() {
 
 get-release-info() {
 declare -ag UBU_URLS=( http://releases.ubuntu.com http://old-releases.ubuntu.com/releases );     
-declare -ag UBU_RELEASES_CSV=($(printf '%s\n' ${UBU_URLS[@]}|(xargs -rn1 -P0 -I{} curl -sSlL {}|awk -vRS=">|<" '/^Ubuntu.[0-9]+.*/{gsub(/\(|\).*$|LTS |Beta /,"");gsub(/\.[0-9]$/,"",$2);split($2,a,/\./);print tolower($2),tolower($3),tolower($4)}')|sort -uV|sed 's/ /,/g'))
+declare -ag UBU_RELEASES_CSV=($(printf '%s\n' ${UBU_URLS[@]}|(xargs -P0 -I{} -rn1 curl -sSlL {}|awk -vRS=">|<" '/^Ubuntu.[0-9]+.*/{gsub(/\(|\).*$|LTS |Beta /,"");gsub(/\.[0-9]$/,"",$2);split($2,a,/\./);print tolower($2),tolower($3),tolower($4)}')|sort -uV|sed 's/ /,/g'))
 printf '%s\n' ${UBU_RELEASES_CSV[@]}|tee 1>/dev/null ${OSSA_WORKDIR}/ubuntu-releases.csv
 };export -f get-release-info
 


### PR DESCRIPTION
For Jammy and Noble the tool got issue with xargs
`xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value`
By reading the manual:

>    	The  options  --max-lines  (-L,  -l), --replace (-I, -i) and --max-args (-n) are mutually exclusive. If some of them are specified at the same time, then xargs will generally use the option specified last on the command line,
>    	i.e., it will reset the value of the offending option (given before) to its default value.  Additionally, xargs will issue a warning diagnostic on stderr.  The exception to this rule is  that  the  special  max-args  value  1
>    	('-n1') is ignored after the --replace option and its aliases -I and -i, because it would not actually conflict.
> 

So the resolution here is just to fix the order of arguments.
